### PR TITLE
Add support for `--run_under` bazel argument

### DIFF
--- a/ibazel/command/notify_command.go
+++ b/ibazel/command/notify_command.go
@@ -89,6 +89,11 @@ func (c *notifyCommand) Start() (*bytes.Buffer, error) {
 }
 
 func (c *notifyCommand) NotifyOfChanges() *bytes.Buffer {
+	if !c.IsSubprocessRunning() {
+		outputBuffer, _ := c.Start()
+		return outputBuffer
+	}
+
 	b := bazelNew()
 	b.SetStartupArgs(c.startupArgs)
 	b.SetArguments(c.bazelArgs)

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -379,6 +379,7 @@ func (i *IBazel) setupRun(target string) command.Command {
 	rule, err := i.queryRule(target)
 	if err != nil {
 		log.Errorf("Error: %v", err)
+		osExit(4)
 	}
 
 	i.targetDecider(target, rule)
@@ -422,8 +423,7 @@ func (i *IBazel) queryRule(rule string) (*blaze_query.Rule, error) {
 
 	res, err := b.Query(rule)
 	if err != nil {
-		log.Errorf("Error running Bazel %v", err)
-		osExit(4)
+		return nil, err
 	}
 
 	for _, target := range res.Target {

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -394,10 +394,10 @@ func (i *IBazel) setupRun(target string) command.Command {
 	}
 
 	// Check also on the tags of the run_under command
-	const prefix = "--run_under="
+	const prefix = "--run_under=//"
 	for _, arg := range i.bazelArgs {
 		if strings.HasPrefix(arg, prefix) {
-			start := len(prefix)
+			start := len(prefix)-2
 			end := 0
 			for end = start; end < len(arg); end++ {
 				if arg[end] == ' ' {

--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -45,6 +45,7 @@ var overrideableBazelFlags []string = []string{
 	"--output_groups=",
 	"--override_repository=",
 	"--repo_env",
+	"--run_under=",
 	"--runs_per_test=",
 	"--stamp=",
 	"--strategy=",


### PR DESCRIPTION
I added the support for the `--run_under` option in iBazel. It is a little more complicated that just adding the option in the supported option list as I also added the code to check for tag on the run_under executable to select the command mode used by iBazel (default or notify).