### PR TITLE
Use SIGTERM for command terminate

### DIFF
--- a/ibazel/command/notify_command.go
+++ b/ibazel/command/notify_command.go
@@ -89,6 +89,11 @@ func (c *notifyCommand) Start() (*bytes.Buffer, error) {
 }
 
 func (c *notifyCommand) NotifyOfChanges() *bytes.Buffer {
+	if !c.IsSubprocessRunning() {
+		outputBuffer, _ := c.Start()
+		return outputBuffer
+	}
+
 	b := bazelNew()
 	b.SetStartupArgs(c.startupArgs)
 	b.SetArguments(c.bazelArgs)

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -420,9 +420,9 @@ func (i *IBazel) setupRun(target string) command.Command {
 
 	if commandNotify {
 		log.Logf("Launching with notifications")
-		return commandNotifyCommand(i.startupArgs, i.bazelArgs, target, i.args)
+		return commandNotifyCommand(i.startupArgs, i.bazelArgs, target, i.args, true)
 	} else {
-		return commandDefaultCommand(i.startupArgs, i.bazelArgs, target, i.args)
+		return commandDefaultCommand(i.startupArgs, i.bazelArgs, target, i.args, true)
 	}
 }
 

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -379,6 +379,7 @@ func (i *IBazel) setupRun(target string) command.Command {
 	rule, err := i.queryRule(target)
 	if err != nil {
 		log.Errorf("Error: %v", err)
+		osExit(4)
 	}
 
 	i.targetDecider(target, rule)
@@ -422,8 +423,7 @@ func (i *IBazel) queryRule(rule string) (*blaze_query.Rule, error) {
 
 	res, err := b.Query(rule)
 	if err != nil {
-		log.Errorf("Error running Bazel %v", err)
-		osExit(4)
+		return nil, err
 	}
 
 	for _, target := range res.Target {

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -394,10 +394,10 @@ func (i *IBazel) setupRun(target string) command.Command {
 	}
 
 	// Check also on the tags of the run_under command
-	const prefix = "--run_under="
+	const prefix = "--run_under=//"
 	for _, arg := range i.bazelArgs {
 		if strings.HasPrefix(arg, prefix) {
-			start := len(prefix)
+			start := len(prefix)-2
 			end := 0
 			for end = start; end < len(arg); end++ {
 				if arg[end] == ' ' {

--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -45,6 +45,7 @@ var overrideableBazelFlags []string = []string{
 	"--output_groups=",
 	"--override_repository=",
 	"--repo_env",
+	"--run_under=",
 	"--runs_per_test=",
 	"--stamp=",
 	"--strategy=",

--- a/ibazel/process_group/process_group.go
+++ b/ibazel/process_group/process_group.go
@@ -35,6 +35,7 @@ type ProcessGroup interface {
 	RootProcess() *exec.Cmd
 	Start() error
 	Kill() error
+	Terminate() error
 	Wait() error
 	Close() error
 	CombinedOutput() ([]byte, error)

--- a/ibazel/process_group/process_group_unix.go
+++ b/ibazel/process_group/process_group_unix.go
@@ -42,7 +42,7 @@ func (pg *unixProcessGroup) Start() error {
 }
 
 func (pg *unixProcessGroup) Kill() error {
-	return syscall.Kill(-pg.root.Process.Pid, syscall.SIGKILL)
+	return syscall.Kill(-pg.root.Process.Pid, syscall.SIGTERM)
 }
 
 func (pg *unixProcessGroup) Wait() error {

--- a/ibazel/process_group/process_group_unix.go
+++ b/ibazel/process_group/process_group_unix.go
@@ -42,6 +42,15 @@ func (pg *unixProcessGroup) Start() error {
 }
 
 func (pg *unixProcessGroup) Kill() error {
+	// Kill it with fire by sending SIGKILL to the process PID which should
+	// propagate down to any subprocesses in the PGID (Process Group ID). To
+	// send to the PGID, send the signal to the negative of the process PID.
+	// Normally I would do this by calling c.cmd.Process.Signal, but that
+	// only goes to the PID not the PGID.
+	return syscall.Kill(-pg.root.Process.Pid, syscall.SIGKILL)
+}
+
+func (pg *unixProcessGroup) Terminate() error {
 	return syscall.Kill(-pg.root.Process.Pid, syscall.SIGTERM)
 }
 

--- a/ibazel/process_group/process_group_windows.go
+++ b/ibazel/process_group/process_group_windows.go
@@ -105,6 +105,11 @@ func (pg *winProcessGroup) Kill() error {
 	return nil
 }
 
+func (pg *winProcessGroup) Terminate() error {
+	// Not yet implemented
+	return pg.Kill()
+}
+
 func (pg *winProcessGroup) Wait() error {
 	var code uint32
 	var key uint32


### PR DESCRIPTION
Using SIGKILL prevent any cleanup to be done for the executed command.
This is an issue if such cleanup is needed.