### PR TITLE
Add command using SIGHUP to signal for changes

### DIFF
--- a/ibazel/command/BUILD
+++ b/ibazel/command/BUILD
@@ -20,6 +20,7 @@ go_library(
         "command.go",
         "default_command.go",
         "notify_command.go",
+        "signal_command.go",
     ],
     importpath = "github.com/bazelbuild/bazel-watcher/ibazel/command",
     visibility = ["//ibazel:__subpackages__"],

--- a/ibazel/command/notify_command.go
+++ b/ibazel/command/notify_command.go
@@ -89,6 +89,11 @@ func (c *notifyCommand) Start() (*bytes.Buffer, error) {
 }
 
 func (c *notifyCommand) NotifyOfChanges() *bytes.Buffer {
+	if !c.IsSubprocessRunning() {
+		outputBuffer, _ := c.Start()
+		return outputBuffer
+	}
+
 	b := bazelNew()
 	b.SetStartupArgs(c.startupArgs)
 	b.SetArguments(c.bazelArgs)

--- a/ibazel/command/signal_command.go
+++ b/ibazel/command/signal_command.go
@@ -1,0 +1,104 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"bytes"
+	"os"
+
+	"github.com/bazelbuild/bazel-watcher/ibazel/log"
+	"github.com/bazelbuild/bazel-watcher/ibazel/process_group"
+)
+
+type signalCommand struct {
+	target      string
+	startupArgs []string
+	bazelArgs   []string
+	args        []string
+	useKill     bool
+
+	pg    process_group.ProcessGroup
+}
+
+// SignalCommand is an alternate mode for starting a command. In this mode the
+// command will be notified by SIGHUP that the source files have changed.
+func SignalCommand(startupArgs []string, bazelArgs []string, target string, args []string, useKill bool) Command {
+	return &signalCommand{
+		startupArgs: startupArgs,
+		target:      target,
+		bazelArgs:   bazelArgs,
+		args:        args,
+		useKill:     useKill,
+	}
+}
+
+func (c *signalCommand) Terminate() {
+	if c.pg != nil && !subprocessRunning(c.pg.RootProcess()) {
+		return
+	}
+
+	if c.useKill {
+		c.pg.Kill()
+	} else {
+		c.pg.Terminate()
+	}
+	c.pg.Wait()
+	c.pg.Close()
+	c.pg = nil
+}
+
+func (c *signalCommand) Start() (*bytes.Buffer, error) {
+	b := bazelNew()
+	b.SetStartupArgs(c.startupArgs)
+	b.SetArguments(c.bazelArgs)
+
+	b.WriteToStderr(true)
+	b.WriteToStdout(true)
+
+	var outputBuffer *bytes.Buffer
+	outputBuffer, c.pg = start(b, c.target, c.args)
+
+	c.pg.RootProcess().Env = append(os.Environ(), "IBAZEL_SIGNAL_CHANGES=y")
+
+	if err := c.pg.Start(); err != nil {
+		log.Errorf("Error starting process: %v", err)
+		return outputBuffer, err
+	}
+	log.Log("Starting...")
+	return outputBuffer, nil
+}
+
+func (c *signalCommand) NotifyOfChanges() *bytes.Buffer {
+	if !c.IsSubprocessRunning() {
+		outputBuffer, _ := c.Start()
+		return outputBuffer
+	}
+
+	b := bazelNew()
+	b.SetStartupArgs(c.startupArgs)
+	b.SetArguments(c.bazelArgs)
+
+	b.WriteToStderr(true)
+	b.WriteToStdout(true)
+
+	outputBuffer, _ := b.Build(c.target)
+
+	c.pg.RefreshSignal()
+	return outputBuffer
+}
+
+func (c *signalCommand) IsSubprocessRunning() bool {
+	return c.pg != nil && subprocessRunning(c.pg.RootProcess())
+}

--- a/ibazel/command/signal_command.go
+++ b/ibazel/command/signal_command.go
@@ -93,9 +93,11 @@ func (c *signalCommand) NotifyOfChanges() *bytes.Buffer {
 	b.WriteToStderr(true)
 	b.WriteToStdout(true)
 
-	outputBuffer, _ := b.Build(c.target)
+	outputBuffer, res := b.Build(c.target)
+	if res == nil {
+		c.pg.RefreshSignal()
+	}
 
-	c.pg.RefreshSignal()
 	return outputBuffer
 }
 

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -420,9 +420,9 @@ func (i *IBazel) setupRun(target string) command.Command {
 
 	if commandNotify {
 		log.Logf("Launching with notifications")
-		return commandNotifyCommand(i.startupArgs, i.bazelArgs, target, i.args)
+		return commandNotifyCommand(i.startupArgs, i.bazelArgs, target, i.args, true)
 	} else {
-		return commandDefaultCommand(i.startupArgs, i.bazelArgs, target, i.args)
+		return commandDefaultCommand(i.startupArgs, i.bazelArgs, target, i.args, true)
 	}
 }
 

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -379,6 +379,7 @@ func (i *IBazel) setupRun(target string) command.Command {
 	rule, err := i.queryRule(target)
 	if err != nil {
 		log.Errorf("Error: %v", err)
+		osExit(4)
 	}
 
 	i.targetDecider(target, rule)
@@ -422,8 +423,7 @@ func (i *IBazel) queryRule(rule string) (*blaze_query.Rule, error) {
 
 	res, err := b.Query(rule)
 	if err != nil {
-		log.Errorf("Error running Bazel %v", err)
-		osExit(4)
+		return nil, err
 	}
 
 	for _, target := range res.Target {

--- a/ibazel/ibazel.go
+++ b/ibazel/ibazel.go
@@ -394,10 +394,10 @@ func (i *IBazel) setupRun(target string) command.Command {
 	}
 
 	// Check also on the tags of the run_under command
-	const prefix = "--run_under="
+	const prefix = "--run_under=//"
 	for _, arg := range i.bazelArgs {
 		if strings.HasPrefix(arg, prefix) {
-			start := len(prefix)
+			start := len(prefix)-2
 			end := 0
 			for end = start; end < len(arg); end++ {
 				if arg[end] == ' ' {

--- a/ibazel/main.go
+++ b/ibazel/main.go
@@ -45,6 +45,7 @@ var overrideableBazelFlags []string = []string{
 	"--output_groups=",
 	"--override_repository=",
 	"--repo_env",
+	"--run_under=",
 	"--runs_per_test=",
 	"--stamp=",
 	"--strategy=",

--- a/ibazel/process_group/process_group.go
+++ b/ibazel/process_group/process_group.go
@@ -36,6 +36,7 @@ type ProcessGroup interface {
 	Start() error
 	Kill() error
 	Terminate() error
+	RefreshSignal() error
 	Wait() error
 	Close() error
 	CombinedOutput() ([]byte, error)

--- a/ibazel/process_group/process_group.go
+++ b/ibazel/process_group/process_group.go
@@ -35,6 +35,7 @@ type ProcessGroup interface {
 	RootProcess() *exec.Cmd
 	Start() error
 	Kill() error
+	Terminate() error
 	Wait() error
 	Close() error
 	CombinedOutput() ([]byte, error)

--- a/ibazel/process_group/process_group_unix.go
+++ b/ibazel/process_group/process_group_unix.go
@@ -42,7 +42,7 @@ func (pg *unixProcessGroup) Start() error {
 }
 
 func (pg *unixProcessGroup) Kill() error {
-	return syscall.Kill(-pg.root.Process.Pid, syscall.SIGKILL)
+	return syscall.Kill(-pg.root.Process.Pid, syscall.SIGTERM)
 }
 
 func (pg *unixProcessGroup) Wait() error {

--- a/ibazel/process_group/process_group_unix.go
+++ b/ibazel/process_group/process_group_unix.go
@@ -42,6 +42,15 @@ func (pg *unixProcessGroup) Start() error {
 }
 
 func (pg *unixProcessGroup) Kill() error {
+	// Kill it with fire by sending SIGKILL to the process PID which should
+	// propagate down to any subprocesses in the PGID (Process Group ID). To
+	// send to the PGID, send the signal to the negative of the process PID.
+	// Normally I would do this by calling c.cmd.Process.Signal, but that
+	// only goes to the PID not the PGID.
+	return syscall.Kill(-pg.root.Process.Pid, syscall.SIGKILL)
+}
+
+func (pg *unixProcessGroup) Terminate() error {
 	return syscall.Kill(-pg.root.Process.Pid, syscall.SIGTERM)
 }
 

--- a/ibazel/process_group/process_group_unix.go
+++ b/ibazel/process_group/process_group_unix.go
@@ -54,6 +54,10 @@ func (pg *unixProcessGroup) Terminate() error {
 	return syscall.Kill(-pg.root.Process.Pid, syscall.SIGTERM)
 }
 
+func (pg *unixProcessGroup) RefreshSignal() error {
+	return syscall.Kill(pg.root.Process.Pid, syscall.SIGHUP)
+}
+
 func (pg *unixProcessGroup) Wait() error {
 	return pg.root.Wait()
 }

--- a/ibazel/process_group/process_group_windows.go
+++ b/ibazel/process_group/process_group_windows.go
@@ -105,6 +105,11 @@ func (pg *winProcessGroup) Kill() error {
 	return nil
 }
 
+func (pg *winProcessGroup) Terminate() error {
+	// Not yet implemented
+	return pg.Kill()
+}
+
 func (pg *winProcessGroup) Wait() error {
 	var code uint32
 	var key uint32


### PR DESCRIPTION
Telepresence uses sudo (this is bad and we should find a way to get rid of this). We need to be able to use sudo thus keep stdin available. So I added another command mode that uses signal SIGHUP to notify changes (the current notify command uses stdin to communicate).

I did not succeed in running the test in the project so I did not add one for the new command yet.